### PR TITLE
feat: add `disableReport` flag to script options

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ License checker for GuideSmiths projects
 
 ## Description
 
-This package allows you to do a quick audit on your NPM dependencies by adding it in your hooks. 
+This package allows you to do a quick audit on your NPM dependencies by adding it in your hooks.
 
 You can optionally add options to exclude generating the report or avoid generating the error report in case a forbidden license is found (see more details [here](#options))
 ## How to use it in your project
@@ -38,6 +38,7 @@ npx @guidesmiths/license-checker --failOn license1,license2
 | --outputFileName | name of the output file generated | string | `licence-report-<timestamp>.md` |
 | --errorReportFileName | name of the file generated when a licence in the failOn option is found | string | `license-error-<timestamp>.md` |
 | --disableErrorReport | flag to disable the error report file generation | boolean | `false` |
+| --disableReport | flag to disable the report file generation, whether there is an error or not | boolean | `false` |
 | -h, --help | Shows help | boolean |   |
 
 ## Useful links

--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ checker.init({
       });
 
       // Generate report with packages containing the licenses passed to `failOn`
-      if (!argv.disableErrorReport) {
+      if (!argv.disableReport && !argv.disableErrorReport) {
         writeReportFile(argv.errorReportFileName, invalidPackageList);
       }
 
@@ -51,6 +51,8 @@ checker.init({
 
   if (!parsedGenerateOutputOnArray.length || packageList.some(p => parsedGenerateOutputOnArray.includes(p.licenses))) {
     console.info('License check completed! No forbidden licenses packages found.');
-    writeReportFile(argv.outputFileName, packageList);
+    if (!argv.disableReport) {
+      writeReportFile(argv.outputFileName, packageList);
+    }
   }
 });

--- a/src/args.js
+++ b/src/args.js
@@ -40,6 +40,11 @@ module.exports = yargs
     type: 'boolean',
     default: false
   })
+  .option('disableReport', {
+    description: 'flag to disable the report file generation, whether there is an error or not',
+    type: 'boolean',
+    default: false
+  })
   .help()
   .alias('help', 'h')
   .argv;


### PR DESCRIPTION
This PR adds a new `disableReport` option to prevent a report file from being generated whether the license check returns an error or not.

### Context:

- :ticket: Closes / Relates #12

### Task list:

:new: **Feature**
- [x] Add new `disableReport` flag to CLI args.
- [x] Don't generate report if `disableReport` is enabled. 

:memo: **Documentation**
- [x] Update `README` file with information on the new option.
