### PR TITLE
refactor: make regex function compatible with node versions prior to v14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [2.0.1](https://github.com/guidesmiths/license-checker/compare/v2.0.0...v2.0.1) (2022-05-09)
+
+
+### 🔄 Code Refactoring
+
+* make regex function compatible with node versions prior to v14 ([262e06e](https://github.com/guidesmiths/license-checker/commit/262e06eee46d54240523bcc97b3b0f86798d37d0))
+
+
+### 🔧 Others
+
+* update package description ([c3e24a6](https://github.com/guidesmiths/license-checker/commit/c3e24a6edeeb2f0b07bb72eccf0e7b7da100e788))
+
 ## [2.0.0](https://github.com/guidesmiths/license-checker/compare/v1.3.0...v2.0.0) (2022-04-26)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@guidesmiths/license-checker",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guidesmiths/license-checker",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Audit your NPM dependencies and reject any forbidden license.",
   "main": "index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@guidesmiths/license-checker",
   "version": "2.0.0",
-  "description": "License checker for GuideSmiths projects",
+  "description": "Audit your NPM dependencies and reject any forbidden license.",
   "main": "index.js",
   "bin": {
     "license-checker": "./index.js"

--- a/src/utils.js
+++ b/src/utils.js
@@ -86,7 +86,7 @@ const writeReportFile = (outputFileName, packageList, customHeaderFileName) => {
  */
 const parseFailOnArgs = args => args.reduce((total, arg) => {
   try {
-    const pattern = /^\/(?<pattern>.+)\/$/.exec(arg)?.groups?.pattern;
+    const pattern = (/^\/(?<pattern>.+)\/$/.exec(arg) || { groups: {} }).groups.pattern;
     return { ...total, valid: [...total.valid, pattern ? new RegExp(pattern) : arg] };
   } catch (e) {
     return { ...total, invalid: [...total.invalid, arg] };


### PR DESCRIPTION
### Main changes

- :arrows_counterclockwise: (refactor): remove optional chaining operator for node backwards compatibility

### Context

- https://github.com/guidesmiths/license-checker/issues/47