### PR TITLE
Refactor/refactor code to enable testing

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,62 +1,16 @@
 #!/usr/bin/env node
 
-const checker = require('license-checker');
+const checker = require('./src/checker');
+const args = require('./src/args');
+const middleware = require('./src/middleware');
+const runner = require('./src/runner');
 
-const argv = require('./src/args');
-const {
-  getPackageInfoList, writeReportFile, parseFailOnArgs, extractInvalidPackages
-} = require('./src/utils');
-
-checker.init({
-  start: argv.start
-}, (err, packages) => {
-  if (err) {
-    console.error('license-checker error:', err);
+(async () => {
+  try {
+    await runner.run(checker, middleware(args));
+    console.info('License check completed! No forbidden licenses packages found.');
+  } catch (e) {
+    console.error(e.message);
     process.exit(1);
   }
-
-  // Generate an array of package info objects
-  const packageList = getPackageInfoList(packages);
-
-  const { failOn } = argv || {};
-  if (failOn) {
-    const { valid: validArgs, invalid } = parseFailOnArgs(failOn);
-    if (invalid.length) {
-      console.error(`The following args passed to --failOn are not valid: ${invalid.join(' ')}`);
-      process.exit(1);
-    }
-
-    const invalidPackageList = extractInvalidPackages(validArgs, packageList);
-
-    // Stop execution if packages were found for the selected licenses
-    if (invalidPackageList.length) {
-      const forbiddenLicenseStats = invalidPackageList
-        .reduce((stats, { licenses }) => ({
-          ...stats,
-          [licenses]: !stats[licenses] ? 1 : stats[licenses] + 1
-        }), {});
-
-      console.error(`Found ${invalidPackageList.length} packages with licenses defined by the --failOn flag:`);
-      Object.keys(forbiddenLicenseStats).forEach(license => {
-        console.error(` > ${forbiddenLicenseStats[license]} packages with license ${license}`);
-      });
-
-      // Generate report with packages containing the licenses passed to `failOn`
-      if (!argv.disableReport && !argv.disableErrorReport) {
-        writeReportFile(argv.errorReportFileName, invalidPackageList, argv.customHeader);
-      }
-
-      process.exit(1);
-    }
-  }
-
-  const parsedGenerateOutputOn = argv.generateOutputOn ? argv.generateOutputOn.split(',') : [];
-  const parsedGenerateOutputOnArray = parsedGenerateOutputOn.map(p => p.trim());
-
-  if (!parsedGenerateOutputOnArray.length || packageList.some(p => parsedGenerateOutputOnArray.includes(p.licenses))) {
-    console.info('License check completed! No forbidden licenses packages found.');
-    if (!argv.disableReport) {
-      writeReportFile(argv.outputFileName, packageList, argv.customHeader);
-    }
-  }
-});
+})();

--- a/src/checker.js
+++ b/src/checker.js
@@ -1,0 +1,14 @@
+const checker = require('license-checker');
+
+const parsePackages = path => new Promise((resolve, reject) => {
+  checker.init({
+    start: path
+  }, (error, packages) => {
+    if (error) reject(new Error(`'license-checker error: ${error}`));
+    else resolve(packages);
+  });
+});
+
+module.exports = {
+  parsePackages
+};

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -1,0 +1,20 @@
+const { parseFailOnArgs } = require('./utils');
+
+const parseRegexLike = args => {
+  const { valid: validArgs, invalid } = parseFailOnArgs(args.failOn || []);
+  if (invalid.length) throw new Error(`The following args passed to --failOn are not valid: ${invalid.join(' ')}`);
+  return { ...args, failOn: validArgs };
+};
+
+const parseGenerateOutputOn = args => {
+  const { generateOutputOn } = args;
+  const parsedOutputOn = generateOutputOn ? generateOutputOn.split(',').map(p => p.trim()) : [];
+  return { ...args, generateOutputOn: parsedOutputOn };
+};
+
+const pipe = (...fns) => x => fns.reduce((v, f) => f(v), x);
+
+module.exports = args => pipe(
+  parseRegexLike,
+  parseGenerateOutputOn
+)(args);

--- a/src/runner.js
+++ b/src/runner.js
@@ -14,8 +14,10 @@ const run = async (checker, args) => {
   }
 
   const packagesIncludeLicenses = packageList.some(p => args.generateOutputOn.includes(p.licenses));
-  if (!args.disableReport && packagesIncludeLicenses) {
-    writeReportFile(args.outputFileName, packageList, args.customHeader);
+  if (!args.generateOutputOn.length || packagesIncludeLicenses) {
+    if (!args.disableReport) {
+      writeReportFile(args.outputFileName, packageList, args.customHeader);
+    }
   }
 };
 

--- a/src/runner.js
+++ b/src/runner.js
@@ -1,0 +1,47 @@
+const {
+  getPackageInfoList, writeReportFile, extractInvalidPackages
+} = require('./utils');
+
+const run = async (checker, args) => {
+  const packages = await checker.parsePackages(args.start);
+
+  const packageList = getPackageInfoList(packages);
+  checkForbiddenLicenses(args, packageList);
+  generateSuccessReport(args, packageList);
+};
+
+const formatForbiddenLicenseError = licenses => {
+  const forbiddenLicenseStats = licenses
+    .reduce((stats, { licenses }) => ({
+      ...stats,
+      [licenses]: !stats[licenses] ? 1 : stats[licenses] + 1
+    }), {});
+
+  const header = `Found ${licenses.length} packages with licenses defined by the --failOn flag:`;
+  const lines = Object
+    .entries(forbiddenLicenseStats)
+    .map(([license, value]) => ` > ${value} packages with license ${license}`)
+    .join('\n');
+
+  return `${header}\n${lines}`;
+};
+
+const checkForbiddenLicenses = ({ errorReportFileName, customHeader, failOn }, packages) => {
+  const forbiddenLicenses = extractInvalidPackages(failOn, packages);
+  if (forbiddenLicenses.length) {
+    writeReportFile(errorReportFileName, forbiddenLicenses, customHeader);
+    throw new Error(formatForbiddenLicenseError(forbiddenLicenses));
+  }
+};
+
+const generateSuccessReport = ({ generateOutputOn, disableReport, outputFileName, customHeader }, packages) => {
+  if (packages.some(p => generateOutputOn.includes(p.licenses))) {
+    if (!disableReport) {
+      writeReportFile(outputFileName, packages, customHeader);
+    }
+  }
+};
+
+module.exports = {
+  run
+};

--- a/src/runner.js
+++ b/src/runner.js
@@ -1,44 +1,21 @@
 const {
-  getPackageInfoList, writeReportFile, extractInvalidPackages
+  getPackageInfoList, writeReportFile, extractInvalidPackages, formatForbiddenLicenseError
 } = require('./utils');
 
 const run = async (checker, args) => {
   const packages = await checker.parsePackages(args.start);
 
   const packageList = getPackageInfoList(packages);
-  checkForbiddenLicenses(args, packageList);
-  generateSuccessReport(args, packageList);
-};
 
-const formatForbiddenLicenseError = licenses => {
-  const forbiddenLicenseStats = licenses
-    .reduce((stats, { licenses }) => ({
-      ...stats,
-      [licenses]: !stats[licenses] ? 1 : stats[licenses] + 1
-    }), {});
-
-  const header = `Found ${licenses.length} packages with licenses defined by the --failOn flag:`;
-  const lines = Object
-    .entries(forbiddenLicenseStats)
-    .map(([license, value]) => ` > ${value} packages with license ${license}`)
-    .join('\n');
-
-  return `${header}\n${lines}`;
-};
-
-const checkForbiddenLicenses = ({ errorReportFileName, customHeader, failOn }, packages) => {
-  const forbiddenLicenses = extractInvalidPackages(failOn, packages);
-  if (forbiddenLicenses.length) {
-    writeReportFile(errorReportFileName, forbiddenLicenses, customHeader);
-    throw new Error(formatForbiddenLicenseError(forbiddenLicenses));
+  const forbiddenPackages = extractInvalidPackages(args.failOn, packageList);
+  if (forbiddenPackages.length) {
+    writeReportFile(args.errorReportFileName, forbiddenPackages, args.customHeader);
+    throw new Error(formatForbiddenLicenseError(forbiddenPackages));
   }
-};
 
-const generateSuccessReport = ({ generateOutputOn, disableReport, outputFileName, customHeader }, packages) => {
-  if (packages.some(p => generateOutputOn.includes(p.licenses))) {
-    if (!disableReport) {
-      writeReportFile(outputFileName, packages, customHeader);
-    }
+  const packagesIncludeLicenses = packageList.some(p => args.generateOutputOn.includes(p.licenses));
+  if (!args.disableReport && packagesIncludeLicenses) {
+    writeReportFile(args.outputFileName, packageList, args.customHeader);
   }
 };
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -115,9 +115,32 @@ const licenseMatchesExpression = (license, expression) => {
 const extractInvalidPackages = (failOnArgs, packages) => packages
   .filter(({ licenses }) => failOnArgs.some(arg => licenseMatchesExpression(licenses, arg)));
 
+/**
+ * Format the forbidden licenses identified in a multiline string
+ *
+ * @param {object[]} licenses - List of licenses identified
+ * @returns {string} - A string with the number and list of forbidden licenses identified
+ */
+const formatForbiddenLicenseError = licenses => {
+  const forbiddenLicenseStats = licenses
+    .reduce((stats, { licenses }) => ({
+      ...stats,
+      [licenses]: !stats[licenses] ? 1 : stats[licenses] + 1
+    }), {});
+
+  const header = `Found ${licenses.length} packages with licenses defined by the --failOn flag:`;
+  const lines = Object
+    .entries(forbiddenLicenseStats)
+    .map(([license, value]) => ` > ${value} packages with license ${license}`)
+    .join('\n');
+
+  return `${header}\n${lines}`;
+};
+
 module.exports = {
   getPackageInfoList,
   writeReportFile,
   extractInvalidPackages,
-  parseFailOnArgs
+  parseFailOnArgs,
+  formatForbiddenLicenseError
 };


### PR DESCRIPTION
### Main changes

- :arrows_counterclockwise: (refactor)

In order to enable unit and end-to-end testing, I propose to split the code into several parts:

- The `index.js` has been simplified and acts as a dependency injector and the only point for error handling:
  -  Retrieves the arguments from `yargs`
  - Uses a `middleware` to run some checks and transform certain arguments. For instance, the arguments passed to `failOn` might include a RegEx. These RegExs must be valid.
  - Execute the core logic by calling the `licence-checker`, which is now wrapped in a promise

### Additional notes

(optional)

### Context

- :ticket: Closes / Relates #51