### PR TITLE
refactor: create file reporter and use different headers per file type

### DIFF
--- a/src/reporter.js
+++ b/src/reporter.js
@@ -1,0 +1,67 @@
+const _ = require('lodash');
+const fs = require('fs');
+
+const defaultReportHeader = 'This application makes use of the following open source packages:';
+const errorReportHeader = 'The following packages use invalid licenses:';
+
+/**
+ *  Generates a table in markdown format with information on the installed
+ * packages, including their licenses.
+ *
+ * @param {object[]} packageList - List of packages to be dumped inside of the file
+ */
+const buildPackageTable = packageList => {
+  const tableHeader = '\n| Library | Version | License | Repository |\n|---|---|---|---|\n';
+
+  const compiled = _.template(
+    `${tableHeader}<% _.forEach(report, elem => { const r = /(.*)@(.*)/.exec(elem.package); %>| <%- r[1] %> | <%- r[2] %> | <%- elem.licenses %> | <%- elem.repository %> |\n<% }); %>`
+  );
+
+  return compiled({ report: packageList });
+};
+
+/**
+ * Generate report file.
+ *
+ * @param {string} header - Value to be used as header of the generated file
+ * @returns {function}
+ */
+const writeReportFile = header =>
+  /**
+   * Generate report file.
+   *
+   * @param {string} outputFileName - Name of the file for the generated report
+   * @param {object[]} packageList - List of packages to be dumped inside the file
+   * @param {string} customHeaderFileName - Name of the file that contains the custom header
+   *  to add at the beginning of the generated report
+   */
+  (outputFileName, packageList, customHeaderFileName) => {
+    let licenseReportHeader = header;
+    if (customHeaderFileName) {
+      try {
+        licenseReportHeader = fs.readFileSync(customHeaderFileName);
+      } catch {
+        console.warn(`Failed to read file ${customHeaderFileName}, so default header will be added to the report`);
+      }
+    }
+
+    const licenseTable = buildPackageTable(packageList);
+
+    fs.writeFileSync(
+    `${outputFileName}.md`,
+    `${licenseReportHeader}\n${licenseTable}`,
+    error => {
+      if (error) {
+        console.error(`Error generating report file ${outputFileName}.md`);
+        throw error;
+      }
+    }
+    );
+
+    console.info(`${outputFileName}.md created!`);
+  };
+
+module.exports = {
+  writeReportFile: writeReportFile(defaultReportHeader),
+  writeErrorReportFile: writeReportFile(errorReportHeader)
+};

--- a/src/runner.js
+++ b/src/runner.js
@@ -1,6 +1,8 @@
 const {
-  getPackageInfoList, writeReportFile, extractInvalidPackages, formatForbiddenLicenseError
+  getPackageInfoList, extractInvalidPackages, formatForbiddenLicenseError
 } = require('./utils');
+
+const reporter = require('./reporter');
 
 const run = async (checker, args) => {
   const packages = await checker.parsePackages(args.start);
@@ -9,14 +11,14 @@ const run = async (checker, args) => {
 
   const forbiddenPackages = extractInvalidPackages(args.failOn, packageList);
   if (forbiddenPackages.length) {
-    writeReportFile(args.errorReportFileName, forbiddenPackages, args.customHeader);
+    reporter.writeErrorReportFile(args.errorReportFileName, forbiddenPackages);
     throw new Error(formatForbiddenLicenseError(forbiddenPackages));
   }
 
   const packagesIncludeLicenses = packageList.some(p => args.generateOutputOn.includes(p.licenses));
   if (!args.generateOutputOn.length || packagesIncludeLicenses) {
     if (!args.disableReport) {
-      writeReportFile(args.outputFileName, packageList, args.customHeader);
+      reporter.writeReportFile(args.outputFileName, packageList, args.customHeader);
     }
   }
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,8 +1,3 @@
-const fs = require('fs');
-const _ = require('lodash');
-
-const defaultReportHeader = 'This application makes use of the following open source packages:';
-
 /**
  * Generate objects with information on each package that we want to include
  * in the report files. This will include metadata such as the package name,
@@ -25,56 +20,6 @@ const getPackageInfoList = packages => Object.entries(packages)
 
     return validInfo;
   });
-
-/**
- *  Generates a table in markdown format with information on the installed
- * packages, including their licenses.
- *
- * @param {object[]} packageList - List of packages to be dumped inside of the file
- */
-const buildPackageTable = packageList => {
-  const tableHeader = '\n| Library | Version | License | Repository |\n|---|---|---|---|\n';
-
-  const compiled = _.template(
-    `${tableHeader}<% _.forEach(report, elem => { const r = /(.*)@(.*)/.exec(elem.package); %>| <%- r[1] %> | <%- r[2] %> | <%- elem.licenses %> | <%- elem.repository %> |\n<% }); %>`
-  );
-
-  return compiled({ report: packageList });
-};
-
-/**
- * Generate report file.
- *
- * @param {string} outputFileName - Name of the file for the generated report
- * @param {object[]} packageList - List of packages to be dumped inside of the file
- * @param {string} customHeaderFileName - Name of the file that contains the custom header
- *  to add at the beginning of the generated report
- */
-const writeReportFile = (outputFileName, packageList, customHeaderFileName) => {
-  let licenseReportHeader = defaultReportHeader;
-  if (customHeaderFileName) {
-    try {
-      licenseReportHeader = fs.readFileSync(customHeaderFileName);
-    } catch {
-      console.warn(`Failed to read file ${customHeaderFileName}, so default header will be added to the report`);
-    }
-  }
-
-  const licenseTable = buildPackageTable(packageList);
-
-  fs.writeFileSync(
-    `${outputFileName}.md`,
-    `${licenseReportHeader}\n${licenseTable}`,
-    error => {
-      if (error) {
-        console.error(`Error generating report file ${outputFileName}.md`);
-        throw error;
-      }
-    }
-  );
-
-  console.info(`${outputFileName}.md created!`);
-};
 
 /**
  * Parses failOn arguments distinguishing between plain string and
@@ -139,7 +84,6 @@ const formatForbiddenLicenseError = licenses => {
 
 module.exports = {
   getPackageInfoList,
-  writeReportFile,
   extractInvalidPackages,
   parseFailOnArgs,
   formatForbiddenLicenseError


### PR DESCRIPTION
### Main changes

- :arrows_counterclockwise: (refactor)

Main changes:

- Move file generation logic to the `reporter.js`
- Curry `writeReportFile` function to accept customized headers. This makes the `reporter.js` expose 2 different functions depending on the file type to generate (error and regular report).
- Use the `reporter` functions on the `runner` to generate the file with the correct header depending on the result.

Not sure if it was intentional, but we are currently passing the `customHeader` value from the program arguments to both types of reports. As the `customHeaderFileName` parameter is optional on the `writeReportFile` function, I just pass nothing from the `runner` when generating the error report. This makes the file be generated with the same header for the errors every time without possible customization. I'm unsure if we want to give the option of customising the header for the error file the same way we do for the regular report. If we do, probable we may want to include an additional option similar to `customHeader`.


### Context

- :ticket: Closes / Relates https://github.com/guidesmiths/license-checker/issues/41