### PR TITLE
feat: add `--ignoreRootPackageLicense`

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ node_modules/.bin/license-checker scan --failOn <license>
 | --disableErrorReport  | Flag to disable the error report file generation                                                                      | false | boolean  | `false` |
 | --disableReport       | Flag to disable the report file generation, whether there is an error or not                                          | false | boolean | `false` |
 | --customHeader        | Name of a text file containing the custom header to add at the start of the generated report                          | false | string | This application makes use of the following open source packages: |
+| --ignoreRootPackageLicense | Flag to ignore the root package license during validation (useful for projects with UNLICENSED or non-SPDX compliant licenses) | false | boolean | `false` |
 
 
 > ❗The options `--failOn` and `--allowOnly` are mutually exclusive. You must use one of them.
@@ -124,6 +125,16 @@ npx @onebeyond/license-checker scan --allowOnly "MIT AND Apache-2.0" GPL-1.0+
 ```
 
 In this example, all the packages' licenses must be either `MIT AND Apache-2.0` **or** `GPL-1.0+`.
+
+#### Ignoring root package license
+
+If your project uses `UNLICENSED` or a non-SPDX compliant license, you can use the `--ignoreRootPackageLicense` flag to exclude the root package from validation:
+
+```sh
+npx @onebeyond/license-checker scan --failOn AGPL-1.0-or-later LGPL-2.0-or-later --ignoreRootPackageLicense
+```
+
+This is useful when you want to validate your dependencies' licenses without failing due to your own project's license.
 
 ## 🔗 Useful links
 

--- a/commands/scan.js
+++ b/commands/scan.js
@@ -51,6 +51,11 @@ exports.builder = {
   customHeader: {
     description: 'name of a text file containing the custom header to add at the start of the generated report',
     type: 'string'
+  },
+  ignoreRootPackageLicense: {
+    description: 'flag to ignore the root package license during validation',
+    type: 'boolean',
+    default: false
   }
 };
 

--- a/src/runner.js
+++ b/src/runner.js
@@ -35,7 +35,7 @@ const scan = async (options) => {
   const spdxLicensesExpression = generateSPDXExpression(licensesList);
 
   const packages = await checker.parsePackages(options.start);
-  const packageList = getPackageInfoList(packages);
+  const packageList = getPackageInfoList(packages, options);
 
   const {
     forbidden: forbiddenPackages,

--- a/src/utils.js
+++ b/src/utils.js
@@ -14,19 +14,34 @@ const licensesExceptions = ['GFDL-1.1-no-invariants-or-later', 'GFDL-1.1-invaria
  *
  * @param {object} packages - Map of packages installed in the project where
  *  the script is run
+ * @param {object} options - Configuration options
+ * @param {boolean} options.ignoreRootPackageLicense - If true, filters out the root package from validation
+ * @param {string} options.start - Path to the project root
  *
  * @returns List of objects with package metadata
  */
-const getPackageInfoList = packages => Object.entries(packages)
-  .map(([key, value]) => {
-    const { path, licenseFile, ...rest } = value;
-    const validInfo = {
-      package: key,
-      ...rest
-    };
+const getPackageInfoList = (packages, options = {}) => {
+  const startPath = options.start || process.cwd();
 
-    return validInfo;
-  });
+  return Object.entries(packages)
+    .filter(([key, value]) => {
+      // Filter out the root package if ignoreRootPackageLicense is enabled
+      // The root package is identified by its path matching the start directory
+      if (options.ignoreRootPackageLicense && value.path === startPath) {
+        return false;
+      }
+      return true;
+    })
+    .map(([key, value]) => {
+      const { path, licenseFile, ...rest } = value;
+      const validInfo = {
+        package: key,
+        ...rest
+      };
+
+      return validInfo;
+    });
+};
 
 /**
  * Format the forbidden licenses identified in a multiline string

--- a/test/scan.test.js
+++ b/test/scan.test.js
@@ -524,4 +524,100 @@ describe('scan command', () => {
       );
     });
   });
+
+  describe('"ignoreRootPackageLicense" option', () => {
+    it('should filter out the root package when ignoreRootPackageLicense is enabled', async () => {
+      const options = {
+        start: '/path/to/cwd',
+        failOn: ['GPL-3.0'],
+        ignoreRootPackageLicense: true
+      };
+
+      const packages = {
+        'root-package@1.0.0': {
+          licenses: 'GPL-3.0',
+          repository: 'https://git.com/repo/root',
+          path: '/path/to/cwd',
+          licenseFile: '/path/to/cwd/LICENSE'
+        },
+        'package-1': {
+          licenses: 'MIT',
+          repository: 'https://git.com/repo/repo',
+          path: '/path/to/cwd/node_modules/package-1',
+          licenseFile: '/path/to/cwd/node_modules/package-1/LICENSE'
+        }
+      };
+
+      parsePackages.mockResolvedValueOnce(packages);
+
+      await expect(scan(options)).resolves.toBeUndefined();
+    });
+
+    it('should include the root package when ignoreRootPackageLicense is disabled', async () => {
+      const options = {
+        start: '/path/to/cwd',
+        failOn: ['GPL-3.0'],
+        ignoreRootPackageLicense: false
+      };
+
+      const packages = {
+        'root-package@1.0.0': {
+          licenses: 'GPL-3.0',
+          repository: 'https://git.com/repo/root',
+          path: '/path/to/cwd',
+          licenseFile: '/path/to/cwd/LICENSE'
+        },
+        'package-1': {
+          licenses: 'MIT',
+          repository: 'https://git.com/repo/repo',
+          path: '/path/to/cwd/node_modules/package-1',
+          licenseFile: '/path/to/cwd/node_modules/package-1/LICENSE'
+        }
+      };
+
+      parsePackages.mockResolvedValueOnce(packages);
+
+      await expect(scan(options)).rejects.toThrow('Found 1 packages with licenses defined by the provided option');
+    });
+
+    it('should filter out root package with non-SPDX compliant licenses (UNLICENSED, UNKNOWN, custom)', async () => {
+      const nonCompliantLicenses = ['UNLICENSED', 'UNKNOWN', 'Custom Proprietary License'];
+
+      for (const license of nonCompliantLicenses) {
+        const options = {
+          start: '/path/to/cwd',
+          failOn: ['GPL-3.0'],
+          ignoreRootPackageLicense: true
+        };
+
+        const packages = {
+          'root-package@1.0.0': {
+            licenses: license,
+            repository: 'https://git.com/repo/root',
+            path: '/path/to/cwd',
+            licenseFile: '/path/to/cwd/LICENSE'
+          },
+          'package-1': {
+            licenses: 'MIT',
+            repository: 'https://git.com/repo/repo',
+            path: '/path/to/cwd/node_modules/package-1',
+            licenseFile: '/path/to/cwd/node_modules/package-1/LICENSE'
+          }
+        };
+
+        parsePackages.mockResolvedValueOnce(packages);
+
+        const warnSpy = jest.spyOn(logger, 'warn');
+
+        await scan(options);
+
+        // Should not show warning about root package
+        if (warnSpy.mock.calls.length > 0) {
+          expect(warnSpy.mock.calls[0][0]).not.toContain('root-package@1.0.0');
+        }
+
+        warnSpy.mockRestore();
+      }
+    });
+  });
 });


### PR DESCRIPTION
Add `--ignoreRootPackageLicense` flag to skip root package validation

Allows projects with UNLICENSED or non-SPDX licenses to validate dependencies without failing on their own license. Filters root package by path comparison. Fixes projects using private/proprietary licenses!

It is a non-breaking change (semver minor compatible)
