### PR TITLE
chore: upgrade lodash

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "chalk": "4.1.2",
         "is-ci": "3.0.1",
         "license-checker": "25.0.1",
-        "lodash": "4.17.21",
+        "lodash": "4.17.23",
         "spdx-expression-validate": "2.0.0",
         "spdx-license-ids": "3.0.13",
         "spdx-satisfies": "5.0.1",
@@ -5287,9 +5287,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w=="
     },
     "node_modules/lodash.camelcase": {
       "version": "4.3.0",
@@ -11336,9 +11336,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w=="
     },
     "lodash.camelcase": {
       "version": "4.3.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "chalk": "4.1.2",
     "is-ci": "3.0.1",
     "license-checker": "25.0.1",
-    "lodash": "4.17.21",
+    "lodash": "4.17.23",
     "spdx-expression-validate": "2.0.0",
     "spdx-license-ids": "3.0.13",
     "spdx-satisfies": "5.0.1",


### PR DESCRIPTION
## Description
This just upgrades Lodash in the package.json and the package-lock.json files, to version 4.17.23, in order to resolve https://nvd.nist.gov/vuln/detail/CVE-2025-13465

## Related Issue
https://github.com/onebeyond/license-checker/issues/114

## Motivation and Context
Lodash has a vulnerability in versions 4.0.0-4.17.22: https://nvd.nist.gov/vuln/detail/CVE-2025-13465

Because this repo uses exact version specifiers for its dependencies, this Lodash version is marked as a vulnerability in all packages that have installed @onebeyond/license-checker.

## How Has This Been Tested?
`npm test` continues to pass.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
